### PR TITLE
feat: pid integral use average(previous, current) error * dt

### DIFF
--- a/features/clamp.c
+++ b/features/clamp.c
@@ -7,12 +7,14 @@
 float pid_update_with_integral_clamp(struct Pid *pid, float error, float dt) {
   float differential = (error - pid->previous) / dt;
 
-  pid->previous = error;
-  pid->integral += error * dt;
+  float average = (error + pid->previous) / 2.0;
+  pid->integral += average * dt;
 
   // clamp integral
   float clamp = pid->option.integral_clamp_bound;
   pid->integral = CLAMP(pid->integral, clamp);
+
+  pid->previous = error;
 
   return pid_weighted_sum(pid, error, pid->integral, differential);
 }

--- a/features/decay.c
+++ b/features/decay.c
@@ -6,10 +6,12 @@
 float pid_update_with_integral_decay(struct Pid *pid, float error, float dt) {
   float differential = (error - pid->previous) / dt;
 
-  pid->previous = error;
+  float average = (error + pid->previous) / 2.0;
   // integral decay
   pid->integral *= pid->option.integral_decay_factor;
-  pid->integral += error * dt;
+  pid->integral += average * dt;
+
+  pid->previous = error;
 
   return pid_weighted_sum(pid, error, pid->integral, differential);
 }

--- a/features/default.c
+++ b/features/default.c
@@ -4,8 +4,10 @@
 float pid_update_with_default(struct Pid *pid, float error, float dt) {
   float differential = (error - pid->previous) / dt;
 
+  float average = (error + pid->previous) / 2.0;
+  pid->integral += average * dt;
+
   pid->previous = error;
-  pid->integral += error * dt;
 
   return pid_weighted_sum(pid, error, pid->integral, differential);
 }

--- a/features/separation.c
+++ b/features/separation.c
@@ -8,10 +8,12 @@ float pid_update_with_integral_separation(struct Pid *pid, float error,
                                           float dt) {
   float differential = (error - pid->previous) / dt;
 
-  pid->previous = error;
   // integral separation
-  if (ABS(error) <= pid->option.integral_separation_error_threshold)
-    pid->integral += error * dt;
+  float average = (error + pid->previous) / 2.0;
+  if (ABS(average) <= pid->option.integral_separation_error_threshold)
+    pid->integral += average * dt;
+
+  pid->previous = error;
 
   return pid_weighted_sum(pid, error, pid->integral, differential);
 }

--- a/features/sliding_window.c
+++ b/features/sliding_window.c
@@ -48,9 +48,11 @@ float pid_update_with_integral_sliding_window(struct Pid *pid, float error,
                                               float dt) {
   float differential = (error - pid->previous) / dt;
 
-  pid->previous = error;
+  float average = (error + pid->previous) / 2.0;
   pid->integral += integral_sliding_window_forward(
-      &pid->option.integral_sliding_window, error, dt);
+      &pid->option.integral_sliding_window, average, dt);
+
+  pid->previous = error;
 
   return pid_weighted_sum(pid, error, pid->integral, differential);
 }


### PR DESCRIPTION
For pids of non-equal duration, dt represents the time from the last pid_update to the current pid_update. During this period, the error of the pid changes from previous to current. Assuming that the error changes linearly during this period, take the average value as the error of this area to reduce the error as much as possible. The best solution is to reduce dt and increase the frequency of pid_update.